### PR TITLE
fix: remove the body in case it is not needed and use robot logger

### DIFF
--- a/src/OpenApiDriver/openapi_executors.py
+++ b/src/OpenApiDriver/openapi_executors.py
@@ -353,7 +353,7 @@ class OpenApiExecutors(OpenApiLibCore):  # pylint: disable=too-many-instance-att
                     )
                 # if the path supports GET, 404 is expected, if not 405 is expected
                 if get_response.status_code not in [404, 405]:
-                    logger.warning(
+                    logger.warn(
                         f"Unexpected response after deleting resource: Status_code "
                         f"{get_response.status_code} was received after trying to get {request_values.url} "
                         f"after sucessfully deleting it."
@@ -392,7 +392,7 @@ class OpenApiExecutors(OpenApiLibCore):  # pylint: disable=too-many-instance-att
 
         request_method = response.request.method
         if request_method is None:
-            logger.warning(
+            logger.warn(
                 f"Could not validate response for path {path}; no method found "
                 f"on the request property of the provided response."
             )
@@ -408,7 +408,7 @@ class OpenApiExecutors(OpenApiLibCore):  # pylint: disable=too-many-instance-att
         mime_type_from_response, _, _ = content_type_from_response.partition(";")
 
         if not response_spec.get("content"):
-            logger.warning(
+            logger.warn(
                 "The response cannot be validated: 'content' not specified in the OAS."
             )
             return None
@@ -506,7 +506,7 @@ class OpenApiExecutors(OpenApiLibCore):  # pylint: disable=too-many-instance-att
                 logger.error(error_message)
                 raise exception
             if self.response_validation == ValidationLevel.WARN:
-                logger.warning(error_message)
+                logger.warn(error_message)
             elif self.response_validation == ValidationLevel.INFO:
                 logger.info(error_message)
 
@@ -610,7 +610,7 @@ class OpenApiExecutors(OpenApiLibCore):  # pylint: disable=too-many-instance-att
 
         python_type = type_mapping.get(expected_type, None)
         if python_type is None:
-            logger.warning(
+            logger.warn(
                 f"Additonal properties were not validated: "
                 f"type '{expected_type}' is not supported."
             )
@@ -686,7 +686,7 @@ class OpenApiExecutors(OpenApiLibCore):  # pylint: disable=too-many-instance-att
                     )
 
         if response.request.body is None:
-            logger.warning(
+            logger.warn(
                 "Could not validate send response; the body of the request property "
                 "on the provided response was None."
             )

--- a/src/OpenApiDriver/openapi_executors.py
+++ b/src/OpenApiDriver/openapi_executors.py
@@ -2,7 +2,7 @@
 
 import json as _json
 from enum import Enum
-from logging import getLogger
+from robot.api import logger
 from pathlib import Path
 from random import choice
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -24,9 +24,6 @@ from robot.api.deco import keyword, library
 from robot.libraries.BuiltIn import BuiltIn
 
 run_keyword = BuiltIn().run_keyword
-
-
-logger = getLogger(__name__)
 
 
 class ValidationLevel(str, Enum):
@@ -171,7 +168,7 @@ class OpenApiExecutors(OpenApiLibCore):  # pylint: disable=too-many-instance-att
         request_data: RequestData = self.get_request_data(method=method, endpoint=path)
         params = request_data.params
         headers = request_data.headers
-        json_data = request_data.dto.as_dict()
+        json_data = request_data.dto.as_dict() if request_data.dto.as_dict() else None
         # when patching, get the original data to check only patched data has changed
         if method == "PATCH":
             original_data = self.get_original_data(url=url)


### PR DESCRIPTION
Using the robot logger to get better info from robot run

Fix the case where a body is not required: it used to send an empty body instead of no body at all, which in my case failed because the server was not expecting any body (it returned error 400 on a simple GET)